### PR TITLE
Feature/sf 19 転送タスク新規追加時に保存ができない

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,1 @@
+-Dfile.encoding=UTF-8

--- a/app/controllers/TransferTaskController.scala
+++ b/app/controllers/TransferTaskController.scala
@@ -52,7 +52,7 @@ class TransferTaskController @Inject() (
   def getTransferTaskListByFormId(hashed_form_id: String): Action[AnyContent] = silhouette.SecuredAction.async { implicit request =>
     val transferTaskEntryList = transferTaskDAO.getTransferTaskListByFormId(hashed_form_id)
       .map(
-        t => { TransferTaskEntry(t.id, t.transfer_type_id, t.name, t.status, t.config.as[JsObject], t.created, t.modified, 0) }
+        t => { TransferTaskEntry(t.id, t.transfer_type_id, t.name, t.status, Json.parse(t.config), t.created, t.modified, 0) }
       )
     val res = RsResultSet("OK", "OK", Json.toJson(transferTaskEntryList))
     Future.successful(Ok(Json.toJson(res)))

--- a/app/controllers/TransferTaskController.scala
+++ b/app/controllers/TransferTaskController.scala
@@ -43,11 +43,13 @@ class TransferTaskController @Inject() (
   def getList: Action[AnyContent] = silhouette.SecuredAction.async { implicit request =>
     Future.successful(Ok(Json.toJson("Not Implemented.")))
   }
+
   // GET /transfertask/id
   def getTransferTask(id: Int): Action[AnyContent] = silhouette.SecuredAction(WithProvider[DefaultEnv#A](CredentialsProvider.ID, List("admin"))).async { implicit request =>
     val res = RsResultSet("OK", "OK", transferTaskDAO.getTransferTask(id))
     Future.successful(Ok(Json.toJson(res)))
   }
+
   // GET /transfertask/list/:form_id
   def getTransferTaskListByFormId(hashed_form_id: String): Action[AnyContent] = silhouette.SecuredAction.async { implicit request =>
     val transferTaskEntryList = transferTaskDAO.getTransferTaskListByFormId(hashed_form_id)

--- a/app/jobs/transfer/MailTransferJob.scala
+++ b/app/jobs/transfer/MailTransferJob.scala
@@ -133,7 +133,8 @@ class MailTransferJob @Inject() (
   }
 
   private def getTransferTaskConfig(transferTask: TransferTask): JsResult[MailTransferTaskConfig] = {
-    transferTask.config.validate[MailTransferTaskConfig]
+    val config = Json.toJson(transferTask.config)
+    config.validate[MailTransferTaskConfig]
   }
 
   private def replaceTag(template: String, postdata: Postdata): String = {

--- a/app/jobs/transfer/SalesforceTransferJob.scala
+++ b/app/jobs/transfer/SalesforceTransferJob.scala
@@ -159,7 +159,8 @@ class SalesforceTransferJob @Inject() (
   }
 
   private def getTransferTaskConfig(transferTask: TransferTask): JsResult[SalesforceTransferTaskConfig] = {
-    transferTask.config.validate[SalesforceTransferTaskConfig]
+    val config = Json.toJson(transferTask.config)
+    config.validate[SalesforceTransferTaskConfig]
   }
 
 }

--- a/app/models/daos/TransferTaskDAO.scala
+++ b/app/models/daos/TransferTaskDAO.scala
@@ -50,7 +50,7 @@ class TransferTaskDAO extends TransferTaskJson {
       WHERE FORM_ID=$hashed_form_id"""
         .map(rs => TransferTask(rs)).list.apply()
       val transferTaskEntityList = transferTaskList.map(
-        t => { TransferTaskEntry(t.id, t.transfer_type_id, t.name, t.status, t.config.as[JsObject], t.created, t.modified, 0) })
+        t => { TransferTaskEntry(t.id, t.transfer_type_id, t.name, t.status, Json.toJson(t.config), t.created, t.modified, 0) })
       Json.toJson(transferTaskEntityList)
     }
   }
@@ -61,7 +61,7 @@ class TransferTaskDAO extends TransferTaskJson {
       FROM D_TRANSFER_TASKS
       WHERE ID=$id"""
         .map(rs => TransferTask(rs)).single.apply().get
-      val transferTaskEntity = TransferTaskEntry(t.id, t.transfer_type_id, t.name, t.status, t.config.as[JsObject], t.created, t.modified, 0)
+      val transferTaskEntity = TransferTaskEntry(t.id, t.transfer_type_id, t.name, t.status, Json.toJson(t.config), t.created, t.modified, 0)
       Json.toJson(transferTaskEntity)
     }
   }
@@ -99,6 +99,7 @@ class TransferTaskDAO extends TransferTaskJson {
   def bulkSave(dt: JsValue, identity: User): Any = {
     val transferTaskList = (dt \ "transferTasks").as[JsValue]
     println(transferTaskList)
+
 
     transferTaskList.validate[Array[TransferTaskEntry]] match {
       case s: JsSuccess[Array[TransferTaskEntry]] =>

--- a/app/models/daos/TransferTaskDAO.scala
+++ b/app/models/daos/TransferTaskDAO.scala
@@ -9,22 +9,6 @@ import scalikejdbc.{ DB, WrappedResultSet }
 
 class TransferTaskDAO extends TransferTaskJson {
 
-  //  case class TransferTask(id: Int, transfer_type_id: Int, name: String, status: Int, config: JsValue,
-  //    created: Option[String], modified: Option[String])
-  //  object TransferTask extends SQLSyntaxSupport[TransferTask] {
-  //    override val tableName = "D_TRANSFER_TASKS"
-  //    def apply(rs: WrappedResultSet): TransferTask = {
-  //      TransferTask(rs.int("id"), rs.int("transfer_type_id"), rs.string("name"), rs.int("status"),
-  //        Json.parse(rs.string("config")), rs.stringOpt("created"), rs.stringOpt("modified"))
-  //    }
-  //  }
-  //  case class TransferTaskJson(id: Int, transfer_type_id: Int, name: String, status: Int, config: JsObject,
-  //    created: Option[String], modified: Option[String], del_flg: Int)
-  //  object TransferTaskJson {
-  //    implicit def jsonTransferTaskWrites: Writes[TransferTaskJson] = Json.writes[TransferTaskJson]
-  //    implicit def jsonTransferTaskReads: Reads[TransferTaskJson] = Json.reads[TransferTaskJson]
-  //  }
-
   def getTransferTaskList(transferType: Int): List[TransferTask] = {
     DB localTx { implicit l =>
       sql"""SELECT ID,TRANSFER_TYPE_ID,NAME,FORM_ID,STATUS,CONFIG,CREATED,MODIFIED
@@ -98,9 +82,6 @@ class TransferTaskDAO extends TransferTaskJson {
 
   def bulkSave(dt: JsValue, identity: User): Any = {
     val transferTaskList = (dt \ "transferTasks").as[JsValue]
-    println(transferTaskList)
-
-
     transferTaskList.validate[Array[TransferTaskEntry]] match {
       case s: JsSuccess[Array[TransferTaskEntry]] =>
         s.get.map(t => {

--- a/app/models/entity/TransferTask.scala
+++ b/app/models/entity/TransferTask.scala
@@ -3,7 +3,7 @@ package models.entity
 import play.api.libs.json.{ JsValue, Json }
 import scalikejdbc._
 
-case class TransferTask(id: Int, transfer_type_id: Int, name: String, status: Int, config: JsValue,
+case class TransferTask(id: Int, transfer_type_id: Int, name: String, status: Int, config: String,
   created: Option[String], modified: Option[String])
 
 object TransferTask extends SQLSyntaxSupport[TransferTask] {
@@ -11,7 +11,7 @@ object TransferTask extends SQLSyntaxSupport[TransferTask] {
 
   def apply(rs: WrappedResultSet): TransferTask = {
     TransferTask(rs.int("id"), rs.int("transfer_type_id"), rs.string("name"), rs.int("status"),
-      Json.parse(rs.string("config")), rs.stringOpt("created"), rs.stringOpt("modified"))
+      rs.string("config"), rs.stringOpt("created"), rs.stringOpt("modified"))
   }
 
 }

--- a/app/models/entity/TransferTask.scala
+++ b/app/models/entity/TransferTask.scala
@@ -1,6 +1,5 @@
 package models.entity
 
-import play.api.libs.json.{ JsValue, Json }
 import scalikejdbc._
 
 case class TransferTask(id: Int, transfer_type_id: Int, name: String, status: Int, config: String,

--- a/app/models/json/TransferTaskJson.scala
+++ b/app/models/json/TransferTaskJson.scala
@@ -7,12 +7,6 @@ import play.api.libs.functional.syntax._
 case class TransferTaskEntry(id: Int, transfer_type_id: Int, name: String, status: Int, config: JsValue,
   created: Option[String], modified: Option[String], del_flg: Int)
 
-object TransferTaskEntry {
-  def apply(id: Int, transfer_type_id: Int, name: String, status: Int, config: JsObject, created: Option[String], modified: Option[String], del_flg: Int): TransferTaskEntry = {
-    TransferTaskEntry(id, transfer_type_id, name, status, config, created, modified, del_flg)
-  }
-}
-
 trait TransferTaskJson {
   implicit val jsonTransferTaskWrites: Writes[TransferTaskEntry] = (transferTaskEntry: TransferTaskEntry) => Json.obj(
     "id" -> transferTaskEntry.id,
@@ -30,7 +24,7 @@ trait TransferTaskJson {
     (JsPath \ "transfer_type_id").read[Int] ~
     (JsPath \ "name").read[String] ~
     (JsPath \ "status").read[Int] ~
-    (JsPath \ "config").read[JsObject] ~
+    (JsPath \ "config").read[JsValue] ~
     (JsPath \ "created").readNullable[String] ~
     (JsPath \ "modified").readNullable[String] ~
     (JsPath \ "del_flg").read[Int]


### PR DESCRIPTION
転送タスク新規追加時に保存ができない現象があり、調査したところ全般に処理がおかしかったので修正。